### PR TITLE
Enhance - Increase Homeassistant Performance

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -3,8 +3,7 @@ name:
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
+
 
 env:
   # TODO: Change variable to your image's name.

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,44 @@
+name: 
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  # TODO: Change variable to your image's name.
+  IMAGE_NAME: enricoferro/yi-hack-2-mqtt
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run build --if-present
+    # - run: npm test
+
+    - name: install buildx
+      id: buildx
+      uses: crazy-max/ghaction-docker-buildx@v1
+      with:
+        version: latest
+    - name: login to docker hub
+      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+    - name: build the image
+      run: |
+        docker buildx build \
+          --tag $IMAGE_NAME:dev  \
+          --output=type=registry \
+          --platform linux/amd64,linux/arm/v7,linux/arm64 .

--- a/src/announce.service.ts
+++ b/src/announce.service.ts
@@ -77,12 +77,12 @@ export class AnnounceService {
         return announce;
     }
 
-    announceSensorGeneric(camera, icon, suffix, suffix_name, unit_of_measurement?, transform = '') {
+    announceSensorGeneric(camera, type, icon, suffix, suffix_name, unit_of_measurement?, transform = '') {
         const announce = this.initAnnunce(
             camera,
             icon,
-            `yicam/${camera}/info`,
-            `yicam/${camera}/info`,
+            `yicam/${camera}/info/${type}`,
+            `yicam/${camera}/info/${type}`,
             `${Configuration.cameras[camera].friendly_name} ${suffix_name}`,
             `${Configuration.mqtt.base_topic}-${camera}-${suffix}`,
             `{{ value_json.${suffix}${transform ? transform : ''} }}`,
@@ -117,12 +117,12 @@ export class AnnounceService {
     }
 
 
-    announceCustomValue(camera, icon, suffix, value_json, suffix_name, unit_of_measurement?, device_class?) {
+    announceCustomValue(camera, type, icon, suffix, value_json, suffix_name, unit_of_measurement?, device_class?) {
         const announce = this.initAnnunce(
             camera,
             icon,
-            `yicam/${camera}/info`,
-            `yicam/${camera}/info`,
+            `yicam/${camera}/info/${type}`,
+            `yicam/${camera}/info/${type}`,
             `${Configuration.cameras[camera].friendly_name} ${suffix_name}`,
             `${Configuration.mqtt.base_topic}-${camera}-${suffix}`,
             `{{ ${value_json} }}`,
@@ -189,68 +189,68 @@ export class AnnounceService {
      * Status.json path
      */
     annunceHostname(camera) {
-        this.announceSensorGeneric(camera, 'mdi:network', 'hostname', 'Hostname');
+        this.announceSensorGeneric(camera, 'global', 'mdi:network', 'hostname', 'Hostname');
     }
 
     annunceIp(camera) {
-        this.announceSensorGeneric(camera, 'mdi:ip', 'local_ip', 'Local IP');
+        this.announceSensorGeneric(camera, 'global', 'mdi:ip', 'local_ip', 'Local IP');
     }
 
     annunceNetmask(camera) {
-        this.announceSensorGeneric(camera, 'mdi:ip', 'netmask', 'Netmask');
+        this.announceSensorGeneric(camera, 'global', 'mdi:ip', 'netmask', 'Netmask');
     }
 
     annunceGateway(camera) {
-        this.announceSensorGeneric(camera, 'mdi:ip', 'gateway', 'Gateway');
+        this.announceSensorGeneric(camera, 'global', 'mdi:ip', 'gateway', 'Gateway');
     }
 
     annunceMacAddress(camera) {
-        this.announceSensorGeneric(camera, 'mdi:network', 'mac_addr', 'Mac Address');
+        this.announceSensorGeneric(camera, 'global', 'mdi:network', 'mac_addr', 'Mac Address');
     }
 
     annunceWlanESSID(camera) {
-        this.announceSensorGeneric(camera, 'mdi:wifi', 'wlan_essid', 'WiFi ESSID');
+        this.announceSensorGeneric(camera, 'global', 'mdi:wifi', 'wlan_essid', 'WiFi ESSID');
     }
 
 
     annunceFirmwareVersion(camera) {
-        this.announceSensorGeneric(camera, 'mdi:network', 'fw_version', 'Firmware Version');
+        this.announceSensorGeneric(camera, 'global', 'mdi:network', 'fw_version', 'Firmware Version');
     }
 
     annunceHomeVersion(camera) {
-        this.announceSensorGeneric(camera, 'mdi:memory', 'home_version', 'Home Version');
+        this.announceSensorGeneric(camera, 'global', 'mdi:memory', 'home_version', 'Home Version');
     }
 
     annunceModelSuffix(camera) {
-        this.announceSensorGeneric(camera, 'mdi:network', 'model_suffix', 'Model Suffix');
+        this.announceSensorGeneric(camera, 'global', 'mdi:network', 'model_suffix', 'Model Suffix');
     }
 
     annunceSerialNumber(camera) {
-        this.announceSensorGeneric(camera, 'mdi:webcam', 'serial_number', 'Serial Number');
+        this.announceSensorGeneric(camera, 'global', 'mdi:webcam', 'serial_number', 'Serial Number');
     }
 
     annunceTotalMemory(camera) {
-        this.announceSensorGeneric(camera, 'mdi:memory', 'total_memory', 'Total Memory', 'KB');
+        this.announceSensorGeneric(camera, 'resources', 'mdi:memory', 'total_memory', 'Total Memory', 'KB');
     }
 
     annunceFreeMemory(camera) {
-        this.announceSensorGeneric(camera, 'mdi:memory', 'free_memory', 'Free Memory', 'KB');
+        this.announceSensorGeneric(camera, 'resources', 'mdi:memory', 'free_memory', 'Free Memory', 'KB');
     }
 
     annunceFreeSD(camera) {
-        this.announceSensorGeneric(camera, 'mdi:micro-sd', 'free_sd', 'Free SD', '%', '|regex_replace(find="%", replace="", ignorecase=False)');
+        this.announceSensorGeneric(camera, 'resources', 'mdi:micro-sd', 'free_sd', 'Free SD', '%', '|regex_replace(find="%", replace="", ignorecase=False)');
     }
 
     annunceLoadAvg(camera) {
-        this.announceSensorGeneric(camera, 'mdi:network', 'load_avg', 'Load AVG');
+        this.announceSensorGeneric(camera, 'resources', 'mdi:network', 'load_avg', 'Load AVG');
     }
 
     announceUptime(camera) {
-        this.announceCustomValue(camera, 'mdi:timer-outline', 'uptime', '(as_timestamp(now())-(value_json.uptime|int))|timestamp_local', 'Uptime', undefined, 'timestamp');
+        this.announceCustomValue(camera, 'resources', 'mdi:timer-outline', 'uptime', '(as_timestamp(now())-(value_json.uptime|int))|timestamp_local', 'Uptime', undefined, 'timestamp');
     }
 
     announceWlanStrengh(camera) {
-        this.announceCustomValue(camera, 'mdi:wifi', 'wlan_strength', '((value_json.wlan_strength|int) * 100 / 70 )|int', 'Wlan Strengh', '%', 'signal_strength');
+        this.announceCustomValue(camera, 'resources', 'mdi:wifi', 'wlan_strength', '((value_json.wlan_strength|int) * 100 / 70 )|int', 'Wlan Strengh', '%', 'signal_strength');
     }
 
     /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,9 @@
 import { NestFactory } from '@nestjs/core';
 import { Transport, MicroserviceOptions } from '@nestjs/microservices';
+import { LogLevel } from '@nestjs/common';
 
 import { YiCamModule } from './yi-cam.module';
 import { Configuration } from './config/configuration';
-import { LogLevel } from '@nestjs/common';
-
 
 function getLogLevel(): LogLevel[] {
   switch (process.env.LOG_LEVEL) {

--- a/src/yi-cam.service.ts
+++ b/src/yi-cam.service.ts
@@ -14,6 +14,12 @@ import { SshProviderService } from './provider/ssh_provider.service';
 export class YICamService {
 
   private readonly logger = new Logger(YICamService.name);
+
+  private globalInfo:any = {};
+  private resourceInfo:any = {};
+  private config:any = {};
+  private link:any = {};
+
   constructor(
     private configService: ConfigService,
     private announceService: AnnounceService,
@@ -23,7 +29,7 @@ export class YICamService {
   }
 
   private getProvider(camera) {
-    const source =  Configuration.global && Configuration.global.provider && Configuration.global.provider.source || Configuration.cameras && Configuration.cameras[camera] && Configuration.cameras[camera].provider && Configuration.cameras[camera].provider.source || 'http';
+    const source = Configuration.global && Configuration.global.provider && Configuration.global.provider.source || Configuration.cameras && Configuration.cameras[camera] && Configuration.cameras[camera].provider && Configuration.cameras[camera].provider.source || 'http';
 
     return source === 'ssh' ? this.sshProviderService : this.httpProviderService;
   }
@@ -32,42 +38,141 @@ export class YICamService {
     this.logger[level](`${topic} ${JSON.stringify(payload)}`);
   }
 
-  publishMqtt(topic,payload) {
+  publishMqtt(topic, payload) {
     const client = mqtt.connect(Configuration.mqtt.server, Configuration.mqtt.options);
     client.publish(topic, payload, { retain: true })
+  }
+
+
+  isLinkChanged(camera, data) {
+    if (this.link[camera] == null || 
+      this.link[camera].low_res_stream !== data.low_res_stream ||
+      this.link[camera].high_res_strea !== data.high_res_strea ||
+      this.link[camera].audio_stream !== data.audio_stream ||
+      this.link[camera].low_res_snapshot !== data.low_res_snapshot ||
+      this.link[camera].high_res_snapshot !== data.high_res_snapshot ) {
+      this.link[camera] = data;
+      return true;
+    } else {
+      return false;
+    }
   }
 
   publishLink(camera: string) {
     const provider = this.getProvider(camera);
     provider.getLink(camera).then((data) => {
-      this.publishMqtt(`${Configuration.mqtt.base_topic}/${camera}/links`, JSON.stringify(data))
+      if (this.isLinkChanged(camera, data)) this.publishMqtt(`${Configuration.mqtt.base_topic}/${camera}/links`, JSON.stringify(data))
     }).catch(err => {
       this.logger.error(`Camera ${camera}: ${err.message}`);
     });
   }
+
+  isGlobalChanged(camera, data) {
+    if (this.globalInfo[camera] == null || 
+      this.globalInfo[camera].hostname !== data.hostname ||
+      this.globalInfo[camera].fw_version !== data.fw_version ||
+      this.globalInfo[camera].home_version !== data.home_version ||
+      this.globalInfo[camera].model_suffix !== data.model_suffix ||
+      this.globalInfo[camera].serial_number !== data.serial_number ||
+      this.globalInfo[camera].local_time !== data.local_time ||
+      this.globalInfo[camera].local_ip !== data.local_ip ||
+      this.globalInfo[camera].netmask !== data.netmask ||
+      this.globalInfo[camera].gateway !== data.gateway ||
+      this.globalInfo[camera].mac_addr !== data.mac_addr ||
+      this.globalInfo[camera].wlan_essid !== data.wlan_essid ) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  getGlobal(camera, data) {
+    if (!this.globalInfo[camera]) this.globalInfo[camera] = {}
+    this.globalInfo[camera].hostname = data.hostname;
+    this.globalInfo[camera].fw_version = data.fw_version;
+    this.globalInfo[camera].home_version = data.home_version;
+    this.globalInfo[camera].model_suffix = data.model_suffix;
+    this.globalInfo[camera].serial_number = data.serial_number;
+    this.globalInfo[camera].local_time = data.local_time;
+    this.globalInfo[camera].local_ip = data.local_ip;
+    this.globalInfo[camera].netmask = data.netmask;
+    this.globalInfo[camera].gateway = data.gateway;
+    this.globalInfo[camera].mac_addr = data.mac_addr;
+    this.globalInfo[camera].wlan_essid = data.wlan_essid;
+    return this.globalInfo[camera];
+  }
+
+  isResourceChanged(camera, data) {
+    if (this.resourceInfo[camera] == null ||
+    this.resourceInfo[camera].local_time !== data.local_time ||
+    this.resourceInfo[camera].uptime !== data.uptime ||
+    this.resourceInfo[camera].load_avg !== data.load_avg ||
+    this.resourceInfo[camera].total_memory !== data.total_memory ||
+    this.resourceInfo[camera].free_memory !== data.free_memory ||
+    this.resourceInfo[camera].free_sd !== data.free_sd ||
+    this.resourceInfo[camera].wlan_strength !== data.wlan_strength ) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  getResources(camera, data) {
+    if (!this.resourceInfo[camera]) this.resourceInfo[camera] = {}
+
+    this.resourceInfo[camera].local_time = data.local_time;
+    this.resourceInfo[camera].uptime = data.uptime;
+    this.resourceInfo[camera].load_avg = data.load_avg;
+    this.resourceInfo[camera].total_memory = data.total_memory;
+    this.resourceInfo[camera].free_memory = data.free_memory;
+    this.resourceInfo[camera].free_sd = data.free_sd;
+    this.resourceInfo[camera].wlan_strength = data.wlan_strength;
+    return this.resourceInfo[camera]
+  }
+
 
   publishStatus(camera: string) {
     const provider = this.getProvider(camera);
     provider.getStatus(camera).then((data) => {
-      this.publishMqtt(`${Configuration.mqtt.base_topic}/${camera}/info`, JSON.stringify(data))
+      delete data.local_time;
+      this.publishMqtt(`${Configuration.mqtt.base_topic}/${camera}/info`, JSON.stringify(data));
+      if (this.isGlobalChanged(camera, data)) this.publishMqtt(`${Configuration.mqtt.base_topic}/${camera}/info/global`, JSON.stringify(this.getGlobal(camera, data)));
+      if (this.isResourceChanged(camera, data)) this.publishMqtt(`${Configuration.mqtt.base_topic}/${camera}/info/resources`, JSON.stringify(this.getResources(camera, data)));
     }).catch(err => {
       this.logger.error(`Camera ${camera}: ${err.message}`);
     });
   }
 
-  publishConfig(camera: string){
+  isConfigChanged(camera, data) {
+    if (this.config[camera] == null || 
+      this.config[camera].SWITCH_ON !== data.SWITCH_ON ||
+      this.config[camera].SAVE_VIDEO_ON_MOTION !== data.SAVE_VIDEO_ON_MOTION ||
+      this.config[camera].SENSITIVITY !== data.SENSITIVITY ||
+      this.config[camera].BABY_CRYING_DETECT !== data.BABY_CRYING_DETECT ||
+      this.config[camera].LED !== data.LED ||
+      this.config[camera].ROTATE !== data.ROTATE ||
+      this.config[camera].IR !== data.IR ||
+      this.config[camera].AI_HUMAN_DETECTION !== data.AI_HUMAN_DETECTION ) {
+      this.config[camera] = data;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  publishConfig(camera: string) {
     const provider = this.getProvider(camera);
     provider.getConfig(camera).then((data) => {
-      this.publishMqtt(`${Configuration.mqtt.base_topic}/${camera}/config`, JSON.stringify(data))
+      if (this.isConfigChanged(camera,data)) this.publishMqtt(`${Configuration.mqtt.base_topic}/${camera}/config`, JSON.stringify(data))
     }).catch(err => {
       this.logger.error(`Camera ${camera}: ${err.message}`);
     });
   }
 
-  publishConfigItem(camera: string, item: string){
+  publishConfigItem(camera: string, item: string) {
     const provider = this.getProvider(camera);
     provider.getConfig(camera).then((data) => {
-      if ( data[item]) {
+      if (data[item]) {
         this.publishMqtt(`${Configuration.mqtt.base_topic}/${camera}/config/${item}`, data[item])
       }
     }).catch(err => {
@@ -75,10 +180,10 @@ export class YICamService {
     });
   }
 
-  setConfigItem(camera: string, item: string, value: string){
+  setConfigItem(camera: string, item: string, value: string) {
     const provider = this.getProvider(camera);
     provider.setConfigItem(camera, item, value).then(() => {
-        this.publishConfig(camera);
+      this.publishConfig(camera);
     }).catch(err => {
       this.logger.error(`Camera ${camera}: ${err.message}`);
     });


### PR DESCRIPTION
This modify create two new mqtt topic:
```
yicam/<yi-camera>/info/resources
yicam/<yi-camera>/info/global
```

The topics in these list is published only if some data is changed:
* `yicam/<yi-camera>/info`
* `yicam/<yi-camera>/info/global`
* `yicam/<yi-camera>/info/resources`
* `yicam/<yi-camera>/links`
* `yicam/<yi-camera>/config`

The announce homeassistant use `yicam/<yi-camera>/info/global` or `yicam/<yi-camera>/info/resources`.
This should reduce the number of the events saved in homeassistant for the mqtt that are not `yicam/<yi-camera>/info/resources`